### PR TITLE
배포환경에서 resource 위치 받아오는 방식 변경

### DIFF
--- a/src/main/java/hongik/discordbots/initializer/service/PythonFileService.java
+++ b/src/main/java/hongik/discordbots/initializer/service/PythonFileService.java
@@ -3,13 +3,12 @@ package hongik.discordbots.initializer.service;
 import hongik.discordbots.initializer.dto.FileDownloadResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.InputStream;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -18,30 +17,31 @@ import java.util.zip.ZipOutputStream;
 @RequiredArgsConstructor
 public class PythonFileService {
 
-    private static final String fileBasePath = "src/main/resources/static/index/";
-    private static final String pythonBasePath = "src/main/resources/static/Python/";
-    private static String[] additionalFiles = {"install_requirements.bat", "install_requirements.sh", "requirements.txt", "settings.py"};
+    private static final String fileBasePath = "static/index/";
+    private static final String pythonBasePath = "static/Python/";
+    private static final String[] additionalFiles = {"install_requirements.bat", "install_requirements.sh", "requirements.txt", "settings.py"};
 
-    // 실행파일 + 봇파일 등 포함해서 zip으로 만들어주는 매서드
+    // 실행 파일 + 봇 파일 등 포함해서 zip으로 만들어주는 메서드
     public FileDownloadResponse createPythonBotZip(List<String> dependencies) {
         try {
-
             // 여기서 실질적인 파이썬 봇 파일 생성
             ByteArrayResource mainPyResource = createPythonBotFile(dependencies);
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                // main.py 파일 추가
                 zos.putNextEntry(new ZipEntry("main.py"));
                 zos.write(mainPyResource.getByteArray());
                 zos.closeEntry();
 
-                // 이 부분 하나의 클래스로 선언해서 불러오는 식으로 변경해야 할 듯
-
+                // 추가 파일들을 ZIP에 포함
                 for (String fileName : additionalFiles) {
-                    Path filePath = Paths.get(fileBasePath, fileName).toAbsolutePath().normalize();
-                    if (Files.exists(filePath)) {
+                    ClassPathResource resource = new ClassPathResource(fileBasePath + fileName);
+                    if (resource.exists()) {
                         zos.putNextEntry(new ZipEntry(fileName));
-                        Files.copy(filePath, zos); // 파일의 모든 내용을 output stream으로 복사
+                        try (InputStream inputStream = resource.getInputStream()) {
+                            inputStream.transferTo(zos); // InputStream을 ZipOutputStream으로 복사
+                        }
                         zos.closeEntry();
                     }
                 }
@@ -53,7 +53,7 @@ public class PythonFileService {
         }
     }
 
-    // 원하는 기능을 가진 파이썬 봇 파일 생성하는 매서드
+    // 원하는 기능을 가진 파이썬 봇 파일 생성하는 메서드
     private ByteArrayResource createPythonBotFile(List<String> dependencies) {
         // Load the contents of the header and footer Python files
         String header = loadFileContent(pythonBasePath + "header.py");
@@ -76,22 +76,19 @@ public class PythonFileService {
         return new ByteArrayResource(mainPyContent.toString().getBytes());
     }
 
-    // 봇 파일 내부에 추가할 내용 불러오는 매서드
+    // 봇 파일 내부에 추가할 내용 불러오는 메서드
     private String loadFileContent(String filePath) {
         try {
-            Path path = Paths.get(filePath).toAbsolutePath().normalize();
-            if (Files.exists(path)) {
-                return Files.readString(path);
-            } else {
-                throw new IllegalArgumentException("File not found: " + filePath);
+            ClassPathResource resource = new ClassPathResource(filePath);
+            try (InputStream inputStream = resource.getInputStream()) {
+                return new String(inputStream.readAllBytes());
             }
         } catch (IOException e) {
             throw new RuntimeException("Error reading file: " + filePath, e);
         }
     }
 
-
-    // 이 매서드는 아직 실행되지 않음
+    // 이 메서드는 아직 실행되지 않음
     public FileDownloadResponse createDependenciesZip(String programmingLanguage, List<String> dependencies) {
         // Create a zip file containing the dependencies for the specified programming language
         // This is a placeholder implementation


### PR DESCRIPTION
jar파일은 class file, resource와 nested jar들로 구성되어 있는데 여기서 resource의 URL은 상단 .jar 루트 경로를 참고해보면 jar://로 시작하는 주소를 가지게 된다.

로컬로 실행했을 땐 실제 resource 파일인 file:// 프로토콜을 사용하기 때문에 File 객체를 생성해 줄 수 있어 해당 경로를 찾아올 수 있었고, .jar 파일은 해당 경로를 찾을 수 없는 것이다.

classloader에게 처리를 위임한 후 InputStream을 통해 처리했다.