### PR TITLE
application.yml 생성 방법 변경(Base 64)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,24 +21,11 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      - uses: actions/checkout@v3
+      - run: touch ./src/main/resources/application.yml
+          echo "${{ secrets.APPLICATION }}" | base64 --decode > ./src/main/resources/application.yml
+      - run: cat ./src/main/resources/application.yml
 
-#      - name: application.yml 파일 만들기
-#        uses: microsoft/variable-substitution@v1
-#        with:
-#          files: ${{ env.BASE_RESOURCE_PATH }}
-#        env:
-#          spring.datasource.url: ${{ secrets.DB_URI }}
-#          spring.datasource.username: ${{ secrets.DB_USERNAME }}
-#          spring.datasource.password: ${{ secrets.DB_PASSWORD }}
-      - name: application.yml 파일 만들기
-        run: |
-          echo "spring.datasource.url: ${DB_URI}" >> ${{ env.BASE_RESOURCE_PATH }}
-          echo "spring.datasource.username: ${DB_USERNAME}" >> ${{ env.BASE_RESOURCE_PATH }}
-          echo "spring.datasource.password: ${DB_PASSWORD}" >> ${{ env.BASE_RESOURCE_PATH }}
-        env:
-          DB_URI: ${{ secrets.DB_URI }}
-          DB_USERNAME: ${{ secrets.DB_USERNAME }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       - name: gradlew에 실행 권한 부여하기
         run: chmod +x ./gradlew
 


### PR DESCRIPTION
기존 application.yml 생성 방법에서 secrets.APPLICATION에 base64로 인코딩 되어 저장된 application.yml 값을 디코딩하여 resource에 저장하는 방식으로 변경

- 특수문자 처리: YAML 파일에는 :, -, 공백 등의 특수문자가 많기 때문에, 이를 인코딩하지 않고 GitHub Secrets에 저장하면 형식 문제로 인해 Actions에서 제대로 파일을 생성하지 못할 수 있음.
- 보안: Base64 인코딩 자체가 보안을 강화하지는 않지만, 내용을 한 줄로 처리할 수 있어 파일 생성 시 형식을 유지하기에 더 유리.